### PR TITLE
feat(api): add OpenAPI-compliant controllers for all domains

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,106 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Install / sync dependencies
+uv sync --all-extras
+
+# Run all tests
+uv run pytest -v
+
+# Run a single test file
+uv run pytest tests/test_tracks.py -v
+
+# Run a single test function
+uv run pytest tests/test_tracks.py::test_create_track -v
+
+# Lint
+uv run ruff check
+uv run ruff format --check
+
+# Type-check
+uv run mypy app/
+
+# Dev server
+uv run uvicorn app.main:app --reload
+
+# Alembic migrations (uses DATABASE_URL from .env or defaults to SQLite)
+uv run alembic revision --autogenerate -m "description"
+uv run alembic upgrade head
+```
+
+## Architecture
+
+```text
+Router → Service → Repository → AsyncSession → DB
+  ↕         ↕          ↕
+Schemas   Errors     Models
+```
+
+**Request flow**: FastAPI router receives request → instantiates Service with Repository → Repository uses async SQLAlchemy session → Service returns Pydantic schema.
+
+**DI pattern**: Session injection via `DbSession = Annotated[AsyncSession, Depends(get_session)]` in `app/dependencies.py`. Routers create service instances inline (no global singletons).
+
+**App factory**: `create_app()` in `app/main.py` with `asynccontextmanager` lifespan that calls `init_db()`/`close_db()`.
+
+### Versioned API routes
+
+- Health: `GET /health` (unversioned, `app/routers/health.py`)
+- All domain routes: `/api/v1/...` via `app/routers/v1/` — each domain gets its own router file
+
+### Adding a new domain (e.g., artists)
+
+1. `app/schemas/artists.py` — Pydantic schemas (`ArtistCreate`, `ArtistRead`, etc.) extending `BaseSchema`
+2. `app/repositories/artists.py` — `ArtistRepository(BaseRepository[Artist])` with `model = Artist`
+3. `app/services/artists.py` — `ArtistService(BaseService)` with business logic
+4. `app/routers/v1/artists.py` — APIRouter, wire service via `_service(db)` pattern
+5. Register router in `app/routers/v1/__init__.py`
+
+### Key abstractions
+
+- **`BaseRepository[ModelT: Base]`** (`app/repositories/base.py`): Generic CRUD using PEP 695 type params. Provides `get_by_id`, `list` (with filters + count), `create`, `update`, `delete`. Subclasses set `model = SomeModel` and add domain-specific queries.
+- **`BaseSchema`** (`app/schemas/base.py`): Pydantic `BaseModel` with `from_attributes=True` and `extra="forbid"`.
+- **`BaseService`** (`app/services/base.py`): Sets up `self.logger`.
+- **`AppError` hierarchy** (`app/errors.py`): `NotFoundError(404)`, `ValidationError(422)`, `ConflictError(409)`. Registered as global exception handlers returning `{code, message, details}` JSON.
+
+## Models & Database
+
+- **DDL source of truth**: `data/schema_v6.sql` (PostgreSQL DDL with pgvector, btree_gist, pg_trgm)
+- **Dev DB**: SQLite via aiosqlite (auto-created by `init_db()` when URL starts with `sqlite`)
+- **Prod DB**: PostgreSQL 16+ with asyncpg
+- **30+ ORM models** in `app/models/` — all re-exported through `app/models/__init__.py`
+
+### Model conventions
+
+- All models inherit from `Base` (DeclarativeBase) in `app/models/base.py`
+- Updatable tables use `TimestampMixin` (created_at + updated_at)
+- Append-only tables use `CreatedAtMixin` (created_at only)
+- **CHECK constraints inline** in `mapped_column()` matching the DDL exactly
+- Domain enums in `app/models/enums.py` are Python `IntEnum`/`StrEnum` — DB stores raw smallint/text, not the enum type
+- `__all__` lists in `__init__.py` must be alphabetically sorted (ruff RUF022)
+
+### SQLite compatibility (tests)
+
+Models must work on both SQLite (tests) and PostgreSQL (prod):
+- Use `JSON` (not `JSONB` from `sqlalchemy.dialects.postgresql`)
+- Use `server_default=func.now()` (not string `"now()"`)
+- pgvector `vector(N)` columns use `String` as placeholder
+- `int4range` columns use `start_ms`/`end_ms` integer pairs instead
+
+### Test fixtures
+
+`tests/conftest.py` provides three async fixtures:
+- `engine` — in-memory SQLite with `create_all`/`drop_all`
+- `session` — async session for direct model tests
+- `client` — httpx `AsyncClient` with `dependency_overrides[get_session]` for API tests
+
+**Critical**: `from app.models import Base` (not `from app.models.base`) — this import triggers all model registrations so `create_all` sees every table.
+
+## Lint & Type Rules
+
+- **ruff**: Python 3.12 target, line-length 88, selected rules: E/F/W/I/N/UP/B/A/SIM/PLW/RUF. `A003` ignored (allow shadowing builtins on class attributes).
+- **mypy**: strict mode with `pydantic.mypy` plugin. `fastmcp` and `alembic` have `ignore_missing_imports`.
+- **pytest-asyncio**: `asyncio_mode = "auto"` — no `@pytest.mark.asyncio` needed on async test functions.

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,14 @@ dev:
 	$(UV) sync --frozen --all-groups
 
 clean:
-	rm -rf build/ dist/ *.egg-info/ .coverage htmlcov/ .pytest_cache/ .ruff_cache/ .mypy_cache/
-	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-	find . -type f -name "*.pyc" -delete 2>/dev/null || true
+	rm -rf build/ dist/ *.egg-info/ .coverage htmlcov/ .pytest_cache/ .ruff_cache/ .mypy_cache/ __pycache__/ */__pycache__/ */*/__pycache__/
+	find . -type d -name "__pycache__" -exec rm -rf {} +
+	find . -type f -name "*.pyc" -delete
+	find . -type f -name "*.pyo" -delete
+	find . -type f -name "*.pyd" -delete
+	find . -type f -name ".coverage" -delete
+	find . -type d -name "*.egg-info" -exec rm -rf {} +
+	find . -type d -name "*.egg" -exec rm -rf {} +
 	@echo "Очищено"
 
 # ═════════════════════════════════════════════════════════════════════════════

--- a/app/repositories/artists.py
+++ b/app/repositories/artists.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from app.models.catalog import Artist
+from app.repositories.base import BaseRepository
+
+
+class ArtistRepository(BaseRepository[Artist]):
+    model = Artist
+
+    async def search_by_name(
+        self, query: str, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Artist], int]:
+        filters: list[Any] = [Artist.name.ilike(f"%{query}%")]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/repositories/genres.py
+++ b/app/repositories/genres.py
@@ -1,0 +1,6 @@
+from app.models.catalog import Genre
+from app.repositories.base import BaseRepository
+
+
+class GenreRepository(BaseRepository[Genre]):
+    model = Genre

--- a/app/repositories/keys.py
+++ b/app/repositories/keys.py
@@ -1,0 +1,6 @@
+from app.models.harmony import Key
+from app.repositories.base import BaseRepository
+
+
+class KeyRepository(BaseRepository[Key]):
+    model = Key

--- a/app/repositories/labels.py
+++ b/app/repositories/labels.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+from app.models.catalog import Label
+from app.repositories.base import BaseRepository
+
+
+class LabelRepository(BaseRepository[Label]):
+    model = Label
+
+    async def search_by_name(
+        self, query: str, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Label], int]:
+        filters: list[Any] = [Label.name.ilike(f"%{query}%")]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/repositories/playlists.py
+++ b/app/repositories/playlists.py
@@ -1,0 +1,24 @@
+from typing import Any
+
+from app.models.dj import DjPlaylist, DjPlaylistItem
+from app.repositories.base import BaseRepository
+
+
+class DjPlaylistRepository(BaseRepository[DjPlaylist]):
+    model = DjPlaylist
+
+    async def search_by_name(
+        self, query: str, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[DjPlaylist], int]:
+        filters: list[Any] = [DjPlaylist.name.ilike(f"%{query}%")]
+        return await self.list(offset=offset, limit=limit, filters=filters)
+
+
+class DjPlaylistItemRepository(BaseRepository[DjPlaylistItem]):
+    model = DjPlaylistItem
+
+    async def list_by_playlist(
+        self, playlist_id: int, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[DjPlaylistItem], int]:
+        filters: list[Any] = [DjPlaylistItem.playlist_id == playlist_id]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/repositories/releases.py
+++ b/app/repositories/releases.py
@@ -1,0 +1,20 @@
+from typing import Any
+
+from app.models.catalog import Release
+from app.repositories.base import BaseRepository
+
+
+class ReleaseRepository(BaseRepository[Release]):
+    model = Release
+
+    async def search_by_title(
+        self, query: str, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Release], int]:
+        filters: list[Any] = [Release.title.ilike(f"%{query}%")]
+        return await self.list(offset=offset, limit=limit, filters=filters)
+
+    async def list_by_label(
+        self, label_id: int, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Release], int]:
+        filters: list[Any] = [Release.label_id == label_id]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/repositories/sets.py
+++ b/app/repositories/sets.py
@@ -1,0 +1,34 @@
+from typing import Any
+
+from app.models.sets import DjSet, DjSetItem, DjSetVersion
+from app.repositories.base import BaseRepository
+
+
+class DjSetRepository(BaseRepository[DjSet]):
+    model = DjSet
+
+    async def search_by_name(
+        self, query: str, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[DjSet], int]:
+        filters: list[Any] = [DjSet.name.ilike(f"%{query}%")]
+        return await self.list(offset=offset, limit=limit, filters=filters)
+
+
+class DjSetVersionRepository(BaseRepository[DjSetVersion]):
+    model = DjSetVersion
+
+    async def list_by_set(
+        self, set_id: int, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[DjSetVersion], int]:
+        filters: list[Any] = [DjSetVersion.set_id == set_id]
+        return await self.list(offset=offset, limit=limit, filters=filters)
+
+
+class DjSetItemRepository(BaseRepository[DjSetItem]):
+    model = DjSetItem
+
+    async def list_by_version(
+        self, set_version_id: int, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[DjSetItem], int]:
+        filters: list[Any] = [DjSetItem.set_version_id == set_version_id]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/repositories/transitions.py
+++ b/app/repositories/transitions.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from app.models.transitions import Transition
+from app.repositories.base import BaseRepository
+
+
+class TransitionRepository(BaseRepository[Transition]):
+    model = Transition
+
+    async def list_by_track(
+        self, track_id: int, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Transition], int]:
+        filters: list[Any] = [
+            (Transition.from_track_id == track_id) | (Transition.to_track_id == track_id),
+        ]
+        return await self.list(offset=offset, limit=limit, filters=filters)
+
+    async def list_by_quality(
+        self, min_quality: float, *, offset: int = 0, limit: int = 50
+    ) -> tuple[list[Transition], int]:
+        filters: list[Any] = [Transition.transition_quality >= min_quality]
+        return await self.list(offset=offset, limit=limit, filters=filters)

--- a/app/routers/v1/__init__.py
+++ b/app/routers/v1/__init__.py
@@ -1,6 +1,24 @@
 from fastapi import APIRouter
 
-from app.routers.v1 import tracks
+from app.routers.v1 import (
+    artists,
+    genres,
+    keys,
+    labels,
+    playlists,
+    releases,
+    sets,
+    tracks,
+    transitions,
+)
 
 v1_router = APIRouter(prefix="/api/v1")
 v1_router.include_router(tracks.router)
+v1_router.include_router(artists.router)
+v1_router.include_router(labels.router)
+v1_router.include_router(releases.router)
+v1_router.include_router(genres.router)
+v1_router.include_router(sets.router)
+v1_router.include_router(playlists.router)
+v1_router.include_router(keys.router)
+v1_router.include_router(transitions.router)

--- a/app/routers/v1/_openapi.py
+++ b/app/routers/v1/_openapi.py
@@ -1,0 +1,19 @@
+"""Shared OpenAPI response definitions for v1 routers."""
+
+from typing import Any
+
+from app.schemas.errors import ErrorResponse
+
+_NOT_FOUND: dict[str, Any] = {
+    "description": "Resource not found",
+    "model": ErrorResponse,
+}
+_CONFLICT: dict[str, Any] = {
+    "description": "Resource conflict",
+    "model": ErrorResponse,
+}
+
+RESPONSES_GET: dict[int | str, dict[str, Any]] = {404: _NOT_FOUND}
+RESPONSES_CREATE: dict[int | str, dict[str, Any]] = {409: _CONFLICT}
+RESPONSES_UPDATE: dict[int | str, dict[str, Any]] = {404: _NOT_FOUND, 409: _CONFLICT}
+RESPONSES_DELETE: dict[int | str, dict[str, Any]] = {404: _NOT_FOUND}

--- a/app/routers/v1/artists.py
+++ b/app/routers/v1/artists.py
@@ -1,0 +1,94 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.artists import ArtistRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.artists import ArtistCreate, ArtistList, ArtistRead, ArtistUpdate
+from app.services.artists import ArtistService
+
+router = APIRouter(prefix="/artists", tags=["artists"])
+
+
+def _service(db: DbSession) -> ArtistService:
+    return ArtistService(ArtistRepository(db))
+
+
+@router.get(
+    "",
+    response_model=ArtistList,
+    summary="List artists",
+    description="Retrieve a paginated list of artists. Supports text search by name.",
+    response_description="Paginated list of artists with total count",
+    operation_id="list_artists",
+)
+async def list_artists(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(
+        default=None, description="Search artists by name (case-insensitive)"
+    ),
+) -> ArtistList:
+    return await _service(db).list(offset=offset, limit=limit, search=search)
+
+
+@router.get(
+    "/{artist_id}",
+    response_model=ArtistRead,
+    summary="Get artist",
+    description="Retrieve a single artist by their unique identifier.",
+    response_description="The artist details",
+    responses=RESPONSES_GET,
+    operation_id="get_artist",
+)
+async def get_artist(artist_id: int, db: DbSession) -> ArtistRead:
+    return await _service(db).get(artist_id)
+
+
+@router.post(
+    "",
+    response_model=ArtistRead,
+    status_code=201,
+    summary="Create artist",
+    description="Create a new artist record.",
+    response_description="The created artist",
+    responses=RESPONSES_CREATE,
+    operation_id="create_artist",
+)
+async def create_artist(data: ArtistCreate, db: DbSession) -> ArtistRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{artist_id}",
+    response_model=ArtistRead,
+    summary="Update artist",
+    description="Partially update an existing artist. Only provided fields are modified.",
+    response_description="The updated artist",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_artist",
+)
+async def update_artist(artist_id: int, data: ArtistUpdate, db: DbSession) -> ArtistRead:
+    result = await _service(db).update(artist_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{artist_id}",
+    status_code=204,
+    summary="Delete artist",
+    description="Permanently delete an artist by ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_artist",
+)
+async def delete_artist(artist_id: int, db: DbSession) -> None:
+    await _service(db).delete(artist_id)
+    await db.commit()

--- a/app/routers/v1/genres.py
+++ b/app/routers/v1/genres.py
@@ -1,0 +1,94 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.genres import GenreRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.genres import GenreCreate, GenreList, GenreRead, GenreUpdate
+from app.services.genres import GenreService
+
+router = APIRouter(prefix="/genres", tags=["genres"])
+
+
+def _service(db: DbSession) -> GenreService:
+    return GenreService(GenreRepository(db))
+
+
+@router.get(
+    "",
+    response_model=GenreList,
+    summary="List genres",
+    description=(
+        "Retrieve a paginated list of genres. "
+        "Genres support a parent hierarchy via `parent_genre_id`."
+    ),
+    response_description="Paginated list of genres with total count",
+    operation_id="list_genres",
+)
+async def list_genres(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+) -> GenreList:
+    return await _service(db).list(offset=offset, limit=limit)
+
+
+@router.get(
+    "/{genre_id}",
+    response_model=GenreRead,
+    summary="Get genre",
+    description="Retrieve a single genre by its unique identifier.",
+    response_description="The genre details",
+    responses=RESPONSES_GET,
+    operation_id="get_genre",
+)
+async def get_genre(genre_id: int, db: DbSession) -> GenreRead:
+    return await _service(db).get(genre_id)
+
+
+@router.post(
+    "",
+    response_model=GenreRead,
+    status_code=201,
+    summary="Create genre",
+    description="Create a new genre. Optionally set `parent_genre_id` for hierarchy.",
+    response_description="The created genre",
+    responses=RESPONSES_CREATE,
+    operation_id="create_genre",
+)
+async def create_genre(data: GenreCreate, db: DbSession) -> GenreRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{genre_id}",
+    response_model=GenreRead,
+    summary="Update genre",
+    description="Partially update an existing genre. Only provided fields are modified.",
+    response_description="The updated genre",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_genre",
+)
+async def update_genre(genre_id: int, data: GenreUpdate, db: DbSession) -> GenreRead:
+    result = await _service(db).update(genre_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{genre_id}",
+    status_code=204,
+    summary="Delete genre",
+    description="Permanently delete a genre by ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_genre",
+)
+async def delete_genre(genre_id: int, db: DbSession) -> None:
+    await _service(db).delete(genre_id)
+    await db.commit()

--- a/app/routers/v1/keys.py
+++ b/app/routers/v1/keys.py
@@ -1,0 +1,47 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.keys import KeyRepository
+from app.routers.v1._openapi import RESPONSES_GET
+from app.schemas.keys import KeyList, KeyRead
+from app.services.keys import KeyService
+
+router = APIRouter(prefix="/keys", tags=["keys"])
+
+
+def _service(db: DbSession) -> KeyService:
+    return KeyService(KeyRepository(db))
+
+
+@router.get(
+    "",
+    response_model=KeyList,
+    summary="List musical keys",
+    description=(
+        "Retrieve all 24 musical keys (12 pitch classes x 2 modes). "
+        "Includes Camelot wheel notation for harmonic mixing."
+    ),
+    response_description="List of all musical keys with total count",
+    operation_id="list_keys",
+)
+async def list_keys(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+) -> KeyList:
+    return await _service(db).list(offset=offset, limit=limit)
+
+
+@router.get(
+    "/{key_code}",
+    response_model=KeyRead,
+    summary="Get musical key",
+    description=(
+        "Retrieve a single musical key by its code (0-23). Key code = pitch_class * 2 + mode."
+    ),
+    response_description="The musical key details with Camelot notation",
+    responses=RESPONSES_GET,
+    operation_id="get_key",
+)
+async def get_key(key_code: int, db: DbSession) -> KeyRead:
+    return await _service(db).get(key_code)

--- a/app/routers/v1/labels.py
+++ b/app/routers/v1/labels.py
@@ -1,0 +1,94 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.labels import LabelRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.labels import LabelCreate, LabelList, LabelRead, LabelUpdate
+from app.services.labels import LabelService
+
+router = APIRouter(prefix="/labels", tags=["labels"])
+
+
+def _service(db: DbSession) -> LabelService:
+    return LabelService(LabelRepository(db))
+
+
+@router.get(
+    "",
+    response_model=LabelList,
+    summary="List labels",
+    description="Retrieve a paginated list of record labels. Supports text search by name.",
+    response_description="Paginated list of labels with total count",
+    operation_id="list_labels",
+)
+async def list_labels(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(
+        default=None, description="Search labels by name (case-insensitive)"
+    ),
+) -> LabelList:
+    return await _service(db).list(offset=offset, limit=limit, search=search)
+
+
+@router.get(
+    "/{label_id}",
+    response_model=LabelRead,
+    summary="Get label",
+    description="Retrieve a single record label by its unique identifier.",
+    response_description="The label details",
+    responses=RESPONSES_GET,
+    operation_id="get_label",
+)
+async def get_label(label_id: int, db: DbSession) -> LabelRead:
+    return await _service(db).get(label_id)
+
+
+@router.post(
+    "",
+    response_model=LabelRead,
+    status_code=201,
+    summary="Create label",
+    description="Create a new record label.",
+    response_description="The created label",
+    responses=RESPONSES_CREATE,
+    operation_id="create_label",
+)
+async def create_label(data: LabelCreate, db: DbSession) -> LabelRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{label_id}",
+    response_model=LabelRead,
+    summary="Update label",
+    description="Partially update an existing record label. Only provided fields are modified.",
+    response_description="The updated label",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_label",
+)
+async def update_label(label_id: int, data: LabelUpdate, db: DbSession) -> LabelRead:
+    result = await _service(db).update(label_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{label_id}",
+    status_code=204,
+    summary="Delete label",
+    description="Permanently delete a record label by ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_label",
+)
+async def delete_label(label_id: int, db: DbSession) -> None:
+    await _service(db).delete(label_id)
+    await db.commit()

--- a/app/routers/v1/playlists.py
+++ b/app/routers/v1/playlists.py
@@ -1,0 +1,167 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.playlists import DjPlaylistItemRepository, DjPlaylistRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.playlists import (
+    DjPlaylistCreate,
+    DjPlaylistItemCreate,
+    DjPlaylistItemList,
+    DjPlaylistItemRead,
+    DjPlaylistList,
+    DjPlaylistRead,
+    DjPlaylistUpdate,
+)
+from app.services.playlists import DjPlaylistService
+
+router = APIRouter(prefix="/playlists", tags=["playlists"])
+
+
+def _service(db: DbSession) -> DjPlaylistService:
+    return DjPlaylistService(
+        DjPlaylistRepository(db),
+        DjPlaylistItemRepository(db),
+    )
+
+
+# ─── Playlist CRUD ───────────────────────────────────────
+
+
+@router.get(
+    "",
+    response_model=DjPlaylistList,
+    summary="List playlists",
+    description="Retrieve a paginated list of DJ playlists. Supports text search by name.",
+    response_description="Paginated list of playlists with total count",
+    operation_id="list_playlists",
+)
+async def list_playlists(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(
+        default=None,
+        description="Search playlists by name (case-insensitive)",
+    ),
+) -> DjPlaylistList:
+    return await _service(db).list(offset=offset, limit=limit, search=search)
+
+
+@router.get(
+    "/{playlist_id}",
+    response_model=DjPlaylistRead,
+    summary="Get playlist",
+    description="Retrieve a single DJ playlist by its unique identifier.",
+    response_description="The playlist details",
+    responses=RESPONSES_GET,
+    operation_id="get_playlist",
+)
+async def get_playlist(playlist_id: int, db: DbSession) -> DjPlaylistRead:
+    return await _service(db).get(playlist_id)
+
+
+@router.post(
+    "",
+    response_model=DjPlaylistRead,
+    status_code=201,
+    summary="Create playlist",
+    description="Create a new DJ playlist. Set `parent_playlist_id` for folder hierarchy.",
+    response_description="The created playlist",
+    responses=RESPONSES_CREATE,
+    operation_id="create_playlist",
+)
+async def create_playlist(data: DjPlaylistCreate, db: DbSession) -> DjPlaylistRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{playlist_id}",
+    response_model=DjPlaylistRead,
+    summary="Update playlist",
+    description="Partially update an existing DJ playlist. Only provided fields are modified.",
+    response_description="The updated playlist",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_playlist",
+)
+async def update_playlist(
+    playlist_id: int, data: DjPlaylistUpdate, db: DbSession
+) -> DjPlaylistRead:
+    result = await _service(db).update(playlist_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{playlist_id}",
+    status_code=204,
+    summary="Delete playlist",
+    description="Permanently delete a DJ playlist and all its items.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_playlist",
+)
+async def delete_playlist(playlist_id: int, db: DbSession) -> None:
+    await _service(db).delete(playlist_id)
+    await db.commit()
+
+
+# ─── Playlist Items ──────────────────────────────────────
+
+
+@router.get(
+    "/{playlist_id}/items",
+    response_model=DjPlaylistItemList,
+    summary="List playlist items",
+    description="Retrieve the ordered track list for a specific playlist.",
+    response_description="Paginated list of playlist items with total count",
+    responses=RESPONSES_GET,
+    operation_id="list_playlist_items",
+)
+async def list_playlist_items(
+    playlist_id: int,
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+) -> DjPlaylistItemList:
+    return await _service(db).list_items(playlist_id, offset=offset, limit=limit)
+
+
+@router.post(
+    "/{playlist_id}/items",
+    response_model=DjPlaylistItemRead,
+    status_code=201,
+    summary="Add item to playlist",
+    description="Add a track to a playlist at the specified sort index.",
+    response_description="The created playlist item",
+    responses=RESPONSES_CREATE,
+    operation_id="add_playlist_item",
+)
+async def add_playlist_item(
+    playlist_id: int, data: DjPlaylistItemCreate, db: DbSession
+) -> DjPlaylistItemRead:
+    result = await _service(db).add_item(playlist_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{playlist_id}/items/{playlist_item_id}",
+    status_code=204,
+    summary="Remove item from playlist",
+    description="Remove a track from a playlist by item ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="remove_playlist_item",
+)
+async def remove_playlist_item(
+    playlist_id: int,
+    playlist_item_id: int,
+    db: DbSession,
+) -> None:
+    await _service(db).remove_item(playlist_item_id)
+    await db.commit()

--- a/app/routers/v1/releases.py
+++ b/app/routers/v1/releases.py
@@ -1,0 +1,99 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.releases import ReleaseRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.releases import ReleaseCreate, ReleaseList, ReleaseRead, ReleaseUpdate
+from app.services.releases import ReleaseService
+
+router = APIRouter(prefix="/releases", tags=["releases"])
+
+
+def _service(db: DbSession) -> ReleaseService:
+    return ReleaseService(ReleaseRepository(db))
+
+
+@router.get(
+    "",
+    response_model=ReleaseList,
+    summary="List releases",
+    description=(
+        "Retrieve a paginated list of releases. "
+        "Supports text search by title and filtering by label."
+    ),
+    response_description="Paginated list of releases with total count",
+    operation_id="list_releases",
+)
+async def list_releases(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(
+        default=None,
+        description="Search releases by title (case-insensitive)",
+    ),
+    label_id: int | None = Query(default=None, description="Filter by label ID"),
+) -> ReleaseList:
+    return await _service(db).list(offset=offset, limit=limit, search=search, label_id=label_id)
+
+
+@router.get(
+    "/{release_id}",
+    response_model=ReleaseRead,
+    summary="Get release",
+    description="Retrieve a single release by its unique identifier.",
+    response_description="The release details",
+    responses=RESPONSES_GET,
+    operation_id="get_release",
+)
+async def get_release(release_id: int, db: DbSession) -> ReleaseRead:
+    return await _service(db).get(release_id)
+
+
+@router.post(
+    "",
+    response_model=ReleaseRead,
+    status_code=201,
+    summary="Create release",
+    description="Create a new release. Optionally link it to a label.",
+    response_description="The created release",
+    responses=RESPONSES_CREATE,
+    operation_id="create_release",
+)
+async def create_release(data: ReleaseCreate, db: DbSession) -> ReleaseRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{release_id}",
+    response_model=ReleaseRead,
+    summary="Update release",
+    description="Partially update an existing release. Only provided fields are modified.",
+    response_description="The updated release",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_release",
+)
+async def update_release(release_id: int, data: ReleaseUpdate, db: DbSession) -> ReleaseRead:
+    result = await _service(db).update(release_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{release_id}",
+    status_code=204,
+    summary="Delete release",
+    description="Permanently delete a release by ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_release",
+)
+async def delete_release(release_id: int, db: DbSession) -> None:
+    await _service(db).delete(release_id)
+    await db.commit()

--- a/app/routers/v1/sets.py
+++ b/app/routers/v1/sets.py
@@ -1,0 +1,195 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.sets import DjSetItemRepository, DjSetRepository, DjSetVersionRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
+from app.schemas.sets import (
+    DjSetCreate,
+    DjSetItemCreate,
+    DjSetItemList,
+    DjSetItemRead,
+    DjSetList,
+    DjSetRead,
+    DjSetUpdate,
+    DjSetVersionCreate,
+    DjSetVersionList,
+    DjSetVersionRead,
+)
+from app.services.sets import DjSetService
+
+router = APIRouter(prefix="/sets", tags=["sets"])
+
+
+def _service(db: DbSession) -> DjSetService:
+    return DjSetService(
+        DjSetRepository(db),
+        DjSetVersionRepository(db),
+        DjSetItemRepository(db),
+    )
+
+
+# ─── Set CRUD ────────────────────────────────────────────
+
+
+@router.get(
+    "",
+    response_model=DjSetList,
+    summary="List DJ sets",
+    description="Retrieve a paginated list of DJ sets. Supports text search by name.",
+    response_description="Paginated list of DJ sets with total count",
+    operation_id="list_sets",
+)
+async def list_sets(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(default=None, description="Search sets by name (case-insensitive)"),
+) -> DjSetList:
+    return await _service(db).list(offset=offset, limit=limit, search=search)
+
+
+@router.get(
+    "/{set_id}",
+    response_model=DjSetRead,
+    summary="Get DJ set",
+    description="Retrieve a single DJ set by its unique identifier.",
+    response_description="The DJ set details including target BPM range and energy arc",
+    responses=RESPONSES_GET,
+    operation_id="get_set",
+)
+async def get_set(set_id: int, db: DbSession) -> DjSetRead:
+    return await _service(db).get(set_id)
+
+
+@router.post(
+    "",
+    response_model=DjSetRead,
+    status_code=201,
+    summary="Create DJ set",
+    description=(
+        "Create a new DJ set with target parameters (duration, BPM range, energy arc). "
+        "Versions and track items are added separately."
+    ),
+    response_description="The created DJ set",
+    responses=RESPONSES_CREATE,
+    operation_id="create_set",
+)
+async def create_set(data: DjSetCreate, db: DbSession) -> DjSetRead:
+    result = await _service(db).create(data)
+    await db.commit()
+    return result
+
+
+@router.patch(
+    "/{set_id}",
+    response_model=DjSetRead,
+    summary="Update DJ set",
+    description="Partially update an existing DJ set. Only provided fields are modified.",
+    response_description="The updated DJ set",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_set",
+)
+async def update_set(set_id: int, data: DjSetUpdate, db: DbSession) -> DjSetRead:
+    result = await _service(db).update(set_id, data)
+    await db.commit()
+    return result
+
+
+@router.delete(
+    "/{set_id}",
+    status_code=204,
+    summary="Delete DJ set",
+    description="Permanently delete a DJ set and all its versions, items, and feedback.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_set",
+)
+async def delete_set(set_id: int, db: DbSession) -> None:
+    await _service(db).delete(set_id)
+    await db.commit()
+
+
+# ─── Set Versions ────────────────────────────────────────
+
+
+@router.get(
+    "/{set_id}/versions",
+    response_model=DjSetVersionList,
+    summary="List set versions",
+    description="Retrieve all versions of a DJ set. Each version is a snapshot of the tracklist.",
+    response_description="Paginated list of set versions with total count",
+    responses=RESPONSES_GET,
+    operation_id="list_set_versions",
+)
+async def list_set_versions(
+    set_id: int,
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+) -> DjSetVersionList:
+    return await _service(db).list_versions(set_id, offset=offset, limit=limit)
+
+
+@router.post(
+    "/{set_id}/versions",
+    response_model=DjSetVersionRead,
+    status_code=201,
+    summary="Create set version",
+    description="Create a new version (snapshot) for a DJ set.",
+    response_description="The created set version",
+    responses=RESPONSES_CREATE,
+    operation_id="create_set_version",
+)
+async def create_set_version(
+    set_id: int, data: DjSetVersionCreate, db: DbSession
+) -> DjSetVersionRead:
+    result = await _service(db).create_version(set_id, data)
+    await db.commit()
+    return result
+
+
+# ─── Set Version Items ───────────────────────────────────
+
+
+@router.get(
+    "/{set_id}/versions/{set_version_id}/items",
+    response_model=DjSetItemList,
+    summary="List set items",
+    description="Retrieve the ordered tracklist for a specific set version.",
+    response_description="Paginated list of set items with total count",
+    responses=RESPONSES_GET,
+    operation_id="list_set_items",
+)
+async def list_set_items(
+    set_id: int,
+    set_version_id: int,
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+) -> DjSetItemList:
+    return await _service(db).list_items(set_version_id, offset=offset, limit=limit)
+
+
+@router.post(
+    "/{set_id}/versions/{set_version_id}/items",
+    response_model=DjSetItemRead,
+    status_code=201,
+    summary="Add item to set version",
+    description="Add a track to a set version at the specified sort index.",
+    response_description="The created set item",
+    responses=RESPONSES_CREATE,
+    operation_id="add_set_item",
+)
+async def add_set_item(
+    set_id: int,
+    set_version_id: int,
+    data: DjSetItemCreate,
+    db: DbSession,
+) -> DjSetItemRead:
+    result = await _service(db).add_item(set_version_id, data)
+    await db.commit()
+    return result

--- a/app/routers/v1/tracks.py
+++ b/app/routers/v1/tracks.py
@@ -2,6 +2,12 @@ from fastapi import APIRouter, Query
 
 from app.dependencies import DbSession
 from app.repositories.tracks import TrackRepository
+from app.routers.v1._openapi import (
+    RESPONSES_CREATE,
+    RESPONSES_DELETE,
+    RESPONSES_GET,
+    RESPONSES_UPDATE,
+)
 from app.schemas.tracks import TrackCreate, TrackList, TrackRead, TrackUpdate
 from app.services.tracks import TrackService
 
@@ -12,39 +18,78 @@ def _service(db: DbSession) -> TrackService:
     return TrackService(TrackRepository(db))
 
 
-@router.get("", response_model=TrackList)
+@router.get(
+    "",
+    response_model=TrackList,
+    summary="List tracks",
+    description="Retrieve a paginated list of tracks. Supports text search by title.",
+    response_description="Paginated list of tracks with total count",
+    operation_id="list_tracks",
+)
 async def list_tracks(
     db: DbSession,
-    offset: int = Query(0, ge=0),
-    limit: int = Query(50, ge=1, le=200),
-    search: str | None = None,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    search: str | None = Query(
+        default=None,
+        description="Search tracks by title (case-insensitive)",
+    ),
 ) -> TrackList:
     return await _service(db).list(offset=offset, limit=limit, search=search)
 
 
-@router.get("/{track_id}", response_model=TrackRead)
+@router.get(
+    "/{track_id}",
+    response_model=TrackRead,
+    summary="Get track",
+    description="Retrieve a single track by its unique identifier.",
+    response_description="The track details",
+    responses=RESPONSES_GET,
+    operation_id="get_track",
+)
 async def get_track(track_id: int, db: DbSession) -> TrackRead:
     return await _service(db).get(track_id)
 
 
-@router.post("", response_model=TrackRead, status_code=201)
+@router.post(
+    "",
+    response_model=TrackRead,
+    status_code=201,
+    summary="Create track",
+    description="Create a new track record with title and duration.",
+    response_description="The created track",
+    responses=RESPONSES_CREATE,
+    operation_id="create_track",
+)
 async def create_track(data: TrackCreate, db: DbSession) -> TrackRead:
-    svc = _service(db)
-    result = await svc.create(data)
+    result = await _service(db).create(data)
     await db.commit()
     return result
 
 
-@router.patch("/{track_id}", response_model=TrackRead)
+@router.patch(
+    "/{track_id}",
+    response_model=TrackRead,
+    summary="Update track",
+    description="Partially update an existing track. Only provided fields are modified.",
+    response_description="The updated track",
+    responses=RESPONSES_UPDATE,
+    operation_id="update_track",
+)
 async def update_track(track_id: int, data: TrackUpdate, db: DbSession) -> TrackRead:
-    svc = _service(db)
-    result = await svc.update(track_id, data)
+    result = await _service(db).update(track_id, data)
     await db.commit()
     return result
 
 
-@router.delete("/{track_id}", status_code=204)
+@router.delete(
+    "/{track_id}",
+    status_code=204,
+    summary="Delete track",
+    description="Permanently delete a track by ID. Cascades to related resources.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_track",
+)
 async def delete_track(track_id: int, db: DbSession) -> None:
-    svc = _service(db)
-    await svc.delete(track_id)
+    await _service(db).delete(track_id)
     await db.commit()

--- a/app/routers/v1/transitions.py
+++ b/app/routers/v1/transitions.py
@@ -1,0 +1,69 @@
+from fastapi import APIRouter, Query
+
+from app.dependencies import DbSession
+from app.repositories.transitions import TransitionRepository
+from app.routers.v1._openapi import RESPONSES_DELETE, RESPONSES_GET
+from app.schemas.transitions import TransitionList, TransitionRead
+from app.services.transitions import TransitionService
+
+router = APIRouter(prefix="/transitions", tags=["transitions"])
+
+
+def _service(db: DbSession) -> TransitionService:
+    return TransitionService(TransitionRepository(db))
+
+
+@router.get(
+    "",
+    response_model=TransitionList,
+    summary="List transitions",
+    description=(
+        "Retrieve computed transitions between tracks. "
+        "Filter by a specific track or minimum quality score."
+    ),
+    response_description="Paginated list of transitions with total count",
+    operation_id="list_transitions",
+)
+async def list_transitions(
+    db: DbSession,
+    offset: int = Query(0, ge=0, description="Number of records to skip"),
+    limit: int = Query(50, ge=1, le=200, description="Max records to return"),
+    track_id: int | None = Query(
+        default=None, description="Filter transitions involving this track (from or to)"
+    ),
+    min_quality: float | None = Query(
+        default=None, ge=0, le=1, description="Minimum transition quality score (0-1)"
+    ),
+) -> TransitionList:
+    return await _service(db).list(
+        offset=offset, limit=limit, track_id=track_id, min_quality=min_quality
+    )
+
+
+@router.get(
+    "/{transition_id}",
+    response_model=TransitionRead,
+    summary="Get transition",
+    description=(
+        "Retrieve a single computed transition by ID. "
+        "Includes scoring components: BPM distance, energy step, groove similarity, etc."
+    ),
+    response_description="The transition details with all scoring components",
+    responses=RESPONSES_GET,
+    operation_id="get_transition",
+)
+async def get_transition(transition_id: int, db: DbSession) -> TransitionRead:
+    return await _service(db).get(transition_id)
+
+
+@router.delete(
+    "/{transition_id}",
+    status_code=204,
+    summary="Delete transition",
+    description="Permanently delete a computed transition by ID.",
+    responses=RESPONSES_DELETE,
+    operation_id="delete_transition",
+)
+async def delete_transition(transition_id: int, db: DbSession) -> None:
+    await _service(db).delete(transition_id)
+    await db.commit()

--- a/app/schemas/artists.py
+++ b/app/schemas/artists.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+
+class ArtistCreate(BaseSchema):
+    name: str = Field(min_length=1, max_length=300)
+    name_sort: str | None = Field(default=None, max_length=300)
+
+
+class ArtistUpdate(BaseSchema):
+    name: str | None = Field(default=None, min_length=1, max_length=300)
+    name_sort: str | None = None
+
+
+class ArtistRead(BaseSchema):
+    artist_id: int
+    name: str
+    name_sort: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ArtistList(BaseSchema):
+    items: list[ArtistRead]
+    total: int

--- a/app/schemas/errors.py
+++ b/app/schemas/errors.py
@@ -1,0 +1,13 @@
+from typing import Any
+
+from pydantic import ConfigDict
+
+from app.schemas.base import BaseSchema
+
+
+class ErrorResponse(BaseSchema):
+    model_config = ConfigDict(from_attributes=False, extra="allow")
+
+    code: str
+    message: str
+    details: dict[str, Any] | None = None

--- a/app/schemas/genres.py
+++ b/app/schemas/genres.py
@@ -1,0 +1,24 @@
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+
+class GenreCreate(BaseSchema):
+    name: str = Field(min_length=1, max_length=200)
+    parent_genre_id: int | None = None
+
+
+class GenreUpdate(BaseSchema):
+    name: str | None = Field(default=None, min_length=1, max_length=200)
+    parent_genre_id: int | None = None
+
+
+class GenreRead(BaseSchema):
+    genre_id: int
+    name: str
+    parent_genre_id: int | None
+
+
+class GenreList(BaseSchema):
+    items: list[GenreRead]
+    total: int

--- a/app/schemas/keys.py
+++ b/app/schemas/keys.py
@@ -1,0 +1,14 @@
+from app.schemas.base import BaseSchema
+
+
+class KeyRead(BaseSchema):
+    key_code: int
+    pitch_class: int
+    mode: int
+    name: str
+    camelot: str | None
+
+
+class KeyList(BaseSchema):
+    items: list[KeyRead]
+    total: int

--- a/app/schemas/labels.py
+++ b/app/schemas/labels.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+
+class LabelCreate(BaseSchema):
+    name: str = Field(min_length=1, max_length=300)
+    name_sort: str | None = Field(default=None, max_length=300)
+
+
+class LabelUpdate(BaseSchema):
+    name: str | None = Field(default=None, min_length=1, max_length=300)
+    name_sort: str | None = None
+
+
+class LabelRead(BaseSchema):
+    label_id: int
+    name: str
+    name_sort: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class LabelList(BaseSchema):
+    items: list[LabelRead]
+    total: int

--- a/app/schemas/playlists.py
+++ b/app/schemas/playlists.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+
+class DjPlaylistCreate(BaseSchema):
+    name: str = Field(min_length=1, max_length=500)
+    parent_playlist_id: int | None = None
+    source_app: int | None = Field(default=None, ge=1, le=5)
+
+
+class DjPlaylistUpdate(BaseSchema):
+    name: str | None = Field(default=None, min_length=1, max_length=500)
+    parent_playlist_id: int | None = None
+    source_app: int | None = Field(default=None, ge=1, le=5)
+
+
+class DjPlaylistRead(BaseSchema):
+    playlist_id: int
+    name: str
+    parent_playlist_id: int | None
+    source_app: int | None
+    created_at: datetime
+
+
+class DjPlaylistList(BaseSchema):
+    items: list[DjPlaylistRead]
+    total: int
+
+
+# --- Playlist Item schemas ---
+
+
+class DjPlaylistItemCreate(BaseSchema):
+    track_id: int
+    sort_index: int = Field(ge=0)
+
+
+class DjPlaylistItemRead(BaseSchema):
+    playlist_item_id: int
+    playlist_id: int
+    track_id: int
+    sort_index: int
+    added_at: datetime | None
+
+
+class DjPlaylistItemList(BaseSchema):
+    items: list[DjPlaylistItemRead]
+    total: int

--- a/app/schemas/releases.py
+++ b/app/schemas/releases.py
@@ -1,0 +1,37 @@
+from datetime import date, datetime
+from typing import Literal
+
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+DatePrecision = Literal["year", "month", "day"]
+
+
+class ReleaseCreate(BaseSchema):
+    title: str = Field(min_length=1, max_length=500)
+    label_id: int | None = None
+    release_date: date | None = None
+    release_date_precision: DatePrecision | None = None
+
+
+class ReleaseUpdate(BaseSchema):
+    title: str | None = Field(default=None, min_length=1, max_length=500)
+    label_id: int | None = None
+    release_date: date | None = None
+    release_date_precision: DatePrecision | None = None
+
+
+class ReleaseRead(BaseSchema):
+    release_id: int
+    title: str
+    label_id: int | None
+    release_date: date | None
+    release_date_precision: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class ReleaseList(BaseSchema):
+    items: list[ReleaseRead]
+    total: int

--- a/app/schemas/sets.py
+++ b/app/schemas/sets.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+from typing import Any
+
+from pydantic import Field
+
+from app.schemas.base import BaseSchema
+
+
+class DjSetCreate(BaseSchema):
+    name: str = Field(min_length=1, max_length=500)
+    description: str | None = None
+    target_duration_ms: int | None = Field(default=None, gt=0)
+    target_bpm_min: float | None = Field(default=None, ge=20, le=300)
+    target_bpm_max: float | None = Field(default=None, ge=20, le=300)
+    target_energy_arc: dict[str, Any] | None = None
+
+
+class DjSetUpdate(BaseSchema):
+    name: str | None = Field(default=None, min_length=1, max_length=500)
+    description: str | None = None
+    target_duration_ms: int | None = Field(default=None, gt=0)
+    target_bpm_min: float | None = Field(default=None, ge=20, le=300)
+    target_bpm_max: float | None = Field(default=None, ge=20, le=300)
+    target_energy_arc: dict[str, Any] | None = None
+
+
+class DjSetRead(BaseSchema):
+    set_id: int
+    name: str
+    description: str | None
+    target_duration_ms: int | None
+    target_bpm_min: float | None
+    target_bpm_max: float | None
+    target_energy_arc: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+
+
+class DjSetList(BaseSchema):
+    items: list[DjSetRead]
+    total: int
+
+
+# --- Set Version schemas ---
+
+
+class DjSetVersionCreate(BaseSchema):
+    version_label: str | None = Field(default=None, max_length=100)
+    generator_run: dict[str, Any] | None = None
+    score: float | None = None
+
+
+class DjSetVersionRead(BaseSchema):
+    set_version_id: int
+    set_id: int
+    version_label: str | None
+    generator_run: dict[str, Any] | None
+    score: float | None
+    created_at: datetime
+
+
+class DjSetVersionList(BaseSchema):
+    items: list[DjSetVersionRead]
+    total: int
+
+
+# --- Set Item schemas ---
+
+
+class DjSetItemCreate(BaseSchema):
+    sort_index: int = Field(ge=0)
+    track_id: int
+    transition_id: int | None = None
+    mix_in_ms: int | None = Field(default=None, ge=0)
+    mix_out_ms: int | None = Field(default=None, ge=0)
+    planned_eq: dict[str, Any] | None = None
+    notes: str | None = None
+
+
+class DjSetItemRead(BaseSchema):
+    set_item_id: int
+    set_version_id: int
+    sort_index: int
+    track_id: int
+    transition_id: int | None
+    in_section_id: int | None
+    out_section_id: int | None
+    mix_in_ms: int | None
+    mix_out_ms: int | None
+    planned_eq: dict[str, Any] | None
+    notes: str | None
+    created_at: datetime
+
+
+class DjSetItemList(BaseSchema):
+    items: list[DjSetItemRead]
+    total: int

--- a/app/schemas/transitions.py
+++ b/app/schemas/transitions.py
@@ -1,0 +1,27 @@
+from datetime import datetime
+
+from app.schemas.base import BaseSchema
+
+
+class TransitionRead(BaseSchema):
+    transition_id: int
+    run_id: int
+    from_track_id: int
+    to_track_id: int
+    from_section_id: int | None
+    to_section_id: int | None
+    overlap_ms: int
+    bpm_distance: float
+    energy_step: float
+    centroid_gap_hz: float | None
+    low_conflict_score: float | None
+    overlap_score: float | None
+    groove_similarity: float | None
+    key_distance_weighted: float | None
+    transition_quality: float
+    computed_at: datetime
+
+
+class TransitionList(BaseSchema):
+    items: list[TransitionRead]
+    total: int

--- a/app/services/artists.py
+++ b/app/services/artists.py
@@ -1,0 +1,45 @@
+from app.errors import NotFoundError
+from app.repositories.artists import ArtistRepository
+from app.schemas.artists import ArtistCreate, ArtistList, ArtistRead, ArtistUpdate
+from app.services.base import BaseService
+
+
+class ArtistService(BaseService):
+    def __init__(self, repo: ArtistRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, artist_id: int) -> ArtistRead:
+        artist = await self.repo.get_by_id(artist_id)
+        if not artist:
+            raise NotFoundError("Artist", artist_id=artist_id)
+        return ArtistRead.model_validate(artist)
+
+    async def list(
+        self, *, offset: int = 0, limit: int = 50, search: str | None = None
+    ) -> ArtistList:
+        if search:
+            items, total = await self.repo.search_by_name(search, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return ArtistList(
+            items=[ArtistRead.model_validate(a) for a in items],
+            total=total,
+        )
+
+    async def create(self, data: ArtistCreate) -> ArtistRead:
+        artist = await self.repo.create(**data.model_dump())
+        return ArtistRead.model_validate(artist)
+
+    async def update(self, artist_id: int, data: ArtistUpdate) -> ArtistRead:
+        artist = await self.repo.get_by_id(artist_id)
+        if not artist:
+            raise NotFoundError("Artist", artist_id=artist_id)
+        updated = await self.repo.update(artist, **data.model_dump(exclude_unset=True))
+        return ArtistRead.model_validate(updated)
+
+    async def delete(self, artist_id: int) -> None:
+        artist = await self.repo.get_by_id(artist_id)
+        if not artist:
+            raise NotFoundError("Artist", artist_id=artist_id)
+        await self.repo.delete(artist)

--- a/app/services/genres.py
+++ b/app/services/genres.py
@@ -1,0 +1,40 @@
+from app.errors import NotFoundError
+from app.repositories.genres import GenreRepository
+from app.schemas.genres import GenreCreate, GenreList, GenreRead, GenreUpdate
+from app.services.base import BaseService
+
+
+class GenreService(BaseService):
+    def __init__(self, repo: GenreRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, genre_id: int) -> GenreRead:
+        genre = await self.repo.get_by_id(genre_id)
+        if not genre:
+            raise NotFoundError("Genre", genre_id=genre_id)
+        return GenreRead.model_validate(genre)
+
+    async def list(self, *, offset: int = 0, limit: int = 50) -> GenreList:
+        items, total = await self.repo.list(offset=offset, limit=limit)
+        return GenreList(
+            items=[GenreRead.model_validate(g) for g in items],
+            total=total,
+        )
+
+    async def create(self, data: GenreCreate) -> GenreRead:
+        genre = await self.repo.create(**data.model_dump())
+        return GenreRead.model_validate(genre)
+
+    async def update(self, genre_id: int, data: GenreUpdate) -> GenreRead:
+        genre = await self.repo.get_by_id(genre_id)
+        if not genre:
+            raise NotFoundError("Genre", genre_id=genre_id)
+        updated = await self.repo.update(genre, **data.model_dump(exclude_unset=True))
+        return GenreRead.model_validate(updated)
+
+    async def delete(self, genre_id: int) -> None:
+        genre = await self.repo.get_by_id(genre_id)
+        if not genre:
+            raise NotFoundError("Genre", genre_id=genre_id)
+        await self.repo.delete(genre)

--- a/app/services/keys.py
+++ b/app/services/keys.py
@@ -1,0 +1,23 @@
+from app.errors import NotFoundError
+from app.repositories.keys import KeyRepository
+from app.schemas.keys import KeyList, KeyRead
+from app.services.base import BaseService
+
+
+class KeyService(BaseService):
+    def __init__(self, repo: KeyRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, key_code: int) -> KeyRead:
+        key = await self.repo.get_by_id(key_code)
+        if not key:
+            raise NotFoundError("Key", key_code=key_code)
+        return KeyRead.model_validate(key)
+
+    async def list(self, *, offset: int = 0, limit: int = 50) -> KeyList:
+        items, total = await self.repo.list(offset=offset, limit=limit)
+        return KeyList(
+            items=[KeyRead.model_validate(k) for k in items],
+            total=total,
+        )

--- a/app/services/labels.py
+++ b/app/services/labels.py
@@ -1,0 +1,45 @@
+from app.errors import NotFoundError
+from app.repositories.labels import LabelRepository
+from app.schemas.labels import LabelCreate, LabelList, LabelRead, LabelUpdate
+from app.services.base import BaseService
+
+
+class LabelService(BaseService):
+    def __init__(self, repo: LabelRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, label_id: int) -> LabelRead:
+        label = await self.repo.get_by_id(label_id)
+        if not label:
+            raise NotFoundError("Label", label_id=label_id)
+        return LabelRead.model_validate(label)
+
+    async def list(
+        self, *, offset: int = 0, limit: int = 50, search: str | None = None
+    ) -> LabelList:
+        if search:
+            items, total = await self.repo.search_by_name(search, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return LabelList(
+            items=[LabelRead.model_validate(lbl) for lbl in items],
+            total=total,
+        )
+
+    async def create(self, data: LabelCreate) -> LabelRead:
+        label = await self.repo.create(**data.model_dump())
+        return LabelRead.model_validate(label)
+
+    async def update(self, label_id: int, data: LabelUpdate) -> LabelRead:
+        label = await self.repo.get_by_id(label_id)
+        if not label:
+            raise NotFoundError("Label", label_id=label_id)
+        updated = await self.repo.update(label, **data.model_dump(exclude_unset=True))
+        return LabelRead.model_validate(updated)
+
+    async def delete(self, label_id: int) -> None:
+        label = await self.repo.get_by_id(label_id)
+        if not label:
+            raise NotFoundError("Label", label_id=label_id)
+        await self.repo.delete(label)

--- a/app/services/playlists.py
+++ b/app/services/playlists.py
@@ -1,0 +1,92 @@
+from app.errors import NotFoundError
+from app.repositories.playlists import DjPlaylistItemRepository, DjPlaylistRepository
+from app.schemas.playlists import (
+    DjPlaylistCreate,
+    DjPlaylistItemCreate,
+    DjPlaylistItemList,
+    DjPlaylistItemRead,
+    DjPlaylistList,
+    DjPlaylistRead,
+    DjPlaylistUpdate,
+)
+from app.services.base import BaseService
+
+
+class DjPlaylistService(BaseService):
+    def __init__(
+        self,
+        repo: DjPlaylistRepository,
+        item_repo: DjPlaylistItemRepository,
+    ) -> None:
+        super().__init__()
+        self.repo = repo
+        self.item_repo = item_repo
+
+    # --- Playlist CRUD ---
+
+    async def get(self, playlist_id: int) -> DjPlaylistRead:
+        playlist = await self.repo.get_by_id(playlist_id)
+        if not playlist:
+            raise NotFoundError("DjPlaylist", playlist_id=playlist_id)
+        return DjPlaylistRead.model_validate(playlist)
+
+    async def list(
+        self, *, offset: int = 0, limit: int = 50, search: str | None = None
+    ) -> DjPlaylistList:
+        if search:
+            items, total = await self.repo.search_by_name(search, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return DjPlaylistList(
+            items=[DjPlaylistRead.model_validate(p) for p in items],
+            total=total,
+        )
+
+    async def create(self, data: DjPlaylistCreate) -> DjPlaylistRead:
+        playlist = await self.repo.create(**data.model_dump())
+        return DjPlaylistRead.model_validate(playlist)
+
+    async def update(self, playlist_id: int, data: DjPlaylistUpdate) -> DjPlaylistRead:
+        playlist = await self.repo.get_by_id(playlist_id)
+        if not playlist:
+            raise NotFoundError("DjPlaylist", playlist_id=playlist_id)
+        updated = await self.repo.update(playlist, **data.model_dump(exclude_unset=True))
+        return DjPlaylistRead.model_validate(updated)
+
+    async def delete(self, playlist_id: int) -> None:
+        playlist = await self.repo.get_by_id(playlist_id)
+        if not playlist:
+            raise NotFoundError("DjPlaylist", playlist_id=playlist_id)
+        await self.repo.delete(playlist)
+
+    # --- Playlist Items ---
+
+    async def list_items(
+        self, playlist_id: int, *, offset: int = 0, limit: int = 50
+    ) -> DjPlaylistItemList:
+        await self._require_playlist(playlist_id)
+        items, total = await self.item_repo.list_by_playlist(
+            playlist_id, offset=offset, limit=limit
+        )
+        return DjPlaylistItemList(
+            items=[DjPlaylistItemRead.model_validate(i) for i in items],
+            total=total,
+        )
+
+    async def add_item(self, playlist_id: int, data: DjPlaylistItemCreate) -> DjPlaylistItemRead:
+        await self._require_playlist(playlist_id)
+        item = await self.item_repo.create(playlist_id=playlist_id, **data.model_dump())
+        return DjPlaylistItemRead.model_validate(item)
+
+    async def remove_item(self, playlist_item_id: int) -> None:
+        item = await self.item_repo.get_by_id(playlist_item_id)
+        if not item:
+            raise NotFoundError("DjPlaylistItem", playlist_item_id=playlist_item_id)
+        await self.item_repo.delete(item)
+
+    # --- Helpers ---
+
+    async def _require_playlist(self, playlist_id: int) -> None:
+        playlist = await self.repo.get_by_id(playlist_id)
+        if not playlist:
+            raise NotFoundError("DjPlaylist", playlist_id=playlist_id)

--- a/app/services/releases.py
+++ b/app/services/releases.py
@@ -1,0 +1,52 @@
+from app.errors import NotFoundError
+from app.repositories.releases import ReleaseRepository
+from app.schemas.releases import ReleaseCreate, ReleaseList, ReleaseRead, ReleaseUpdate
+from app.services.base import BaseService
+
+
+class ReleaseService(BaseService):
+    def __init__(self, repo: ReleaseRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, release_id: int) -> ReleaseRead:
+        release = await self.repo.get_by_id(release_id)
+        if not release:
+            raise NotFoundError("Release", release_id=release_id)
+        return ReleaseRead.model_validate(release)
+
+    async def list(
+        self,
+        *,
+        offset: int = 0,
+        limit: int = 50,
+        search: str | None = None,
+        label_id: int | None = None,
+    ) -> ReleaseList:
+        if search:
+            items, total = await self.repo.search_by_title(search, offset=offset, limit=limit)
+        elif label_id is not None:
+            items, total = await self.repo.list_by_label(label_id, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return ReleaseList(
+            items=[ReleaseRead.model_validate(r) for r in items],
+            total=total,
+        )
+
+    async def create(self, data: ReleaseCreate) -> ReleaseRead:
+        release = await self.repo.create(**data.model_dump())
+        return ReleaseRead.model_validate(release)
+
+    async def update(self, release_id: int, data: ReleaseUpdate) -> ReleaseRead:
+        release = await self.repo.get_by_id(release_id)
+        if not release:
+            raise NotFoundError("Release", release_id=release_id)
+        updated = await self.repo.update(release, **data.model_dump(exclude_unset=True))
+        return ReleaseRead.model_validate(updated)
+
+    async def delete(self, release_id: int) -> None:
+        release = await self.repo.get_by_id(release_id)
+        if not release:
+            raise NotFoundError("Release", release_id=release_id)
+        await self.repo.delete(release)

--- a/app/services/sets.py
+++ b/app/services/sets.py
@@ -1,0 +1,119 @@
+from app.errors import NotFoundError
+from app.repositories.sets import DjSetItemRepository, DjSetRepository, DjSetVersionRepository
+from app.schemas.sets import (
+    DjSetCreate,
+    DjSetItemCreate,
+    DjSetItemList,
+    DjSetItemRead,
+    DjSetList,
+    DjSetRead,
+    DjSetUpdate,
+    DjSetVersionCreate,
+    DjSetVersionList,
+    DjSetVersionRead,
+)
+from app.services.base import BaseService
+
+
+class DjSetService(BaseService):
+    def __init__(
+        self,
+        repo: DjSetRepository,
+        version_repo: DjSetVersionRepository,
+        item_repo: DjSetItemRepository,
+    ) -> None:
+        super().__init__()
+        self.repo = repo
+        self.version_repo = version_repo
+        self.item_repo = item_repo
+
+    # --- Set CRUD ---
+
+    async def get(self, set_id: int) -> DjSetRead:
+        dj_set = await self.repo.get_by_id(set_id)
+        if not dj_set:
+            raise NotFoundError("DjSet", set_id=set_id)
+        return DjSetRead.model_validate(dj_set)
+
+    async def list(
+        self, *, offset: int = 0, limit: int = 50, search: str | None = None
+    ) -> DjSetList:
+        if search:
+            items, total = await self.repo.search_by_name(search, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return DjSetList(
+            items=[DjSetRead.model_validate(s) for s in items],
+            total=total,
+        )
+
+    async def create(self, data: DjSetCreate) -> DjSetRead:
+        dj_set = await self.repo.create(**data.model_dump())
+        return DjSetRead.model_validate(dj_set)
+
+    async def update(self, set_id: int, data: DjSetUpdate) -> DjSetRead:
+        dj_set = await self.repo.get_by_id(set_id)
+        if not dj_set:
+            raise NotFoundError("DjSet", set_id=set_id)
+        updated = await self.repo.update(dj_set, **data.model_dump(exclude_unset=True))
+        return DjSetRead.model_validate(updated)
+
+    async def delete(self, set_id: int) -> None:
+        dj_set = await self.repo.get_by_id(set_id)
+        if not dj_set:
+            raise NotFoundError("DjSet", set_id=set_id)
+        await self.repo.delete(dj_set)
+
+    # --- Version CRUD ---
+
+    async def list_versions(
+        self, set_id: int, *, offset: int = 0, limit: int = 50
+    ) -> DjSetVersionList:
+        await self._require_set(set_id)
+        items, total = await self.version_repo.list_by_set(set_id, offset=offset, limit=limit)
+        return DjSetVersionList(
+            items=[DjSetVersionRead.model_validate(v) for v in items],
+            total=total,
+        )
+
+    async def create_version(self, set_id: int, data: DjSetVersionCreate) -> DjSetVersionRead:
+        await self._require_set(set_id)
+        version = await self.version_repo.create(set_id=set_id, **data.model_dump())
+        return DjSetVersionRead.model_validate(version)
+
+    async def get_version(self, set_version_id: int) -> DjSetVersionRead:
+        version = await self.version_repo.get_by_id(set_version_id)
+        if not version:
+            raise NotFoundError("DjSetVersion", set_version_id=set_version_id)
+        return DjSetVersionRead.model_validate(version)
+
+    # --- Item CRUD ---
+
+    async def list_items(
+        self, set_version_id: int, *, offset: int = 0, limit: int = 50
+    ) -> DjSetItemList:
+        await self._require_version(set_version_id)
+        items, total = await self.item_repo.list_by_version(
+            set_version_id, offset=offset, limit=limit
+        )
+        return DjSetItemList(
+            items=[DjSetItemRead.model_validate(i) for i in items],
+            total=total,
+        )
+
+    async def add_item(self, set_version_id: int, data: DjSetItemCreate) -> DjSetItemRead:
+        await self._require_version(set_version_id)
+        item = await self.item_repo.create(set_version_id=set_version_id, **data.model_dump())
+        return DjSetItemRead.model_validate(item)
+
+    # --- Helpers ---
+
+    async def _require_set(self, set_id: int) -> None:
+        dj_set = await self.repo.get_by_id(set_id)
+        if not dj_set:
+            raise NotFoundError("DjSet", set_id=set_id)
+
+    async def _require_version(self, set_version_id: int) -> None:
+        version = await self.version_repo.get_by_id(set_version_id)
+        if not version:
+            raise NotFoundError("DjSetVersion", set_version_id=set_version_id)

--- a/app/services/transitions.py
+++ b/app/services/transitions.py
@@ -1,0 +1,41 @@
+from app.errors import NotFoundError
+from app.repositories.transitions import TransitionRepository
+from app.schemas.transitions import TransitionList, TransitionRead
+from app.services.base import BaseService
+
+
+class TransitionService(BaseService):
+    def __init__(self, repo: TransitionRepository) -> None:
+        super().__init__()
+        self.repo = repo
+
+    async def get(self, transition_id: int) -> TransitionRead:
+        transition = await self.repo.get_by_id(transition_id)
+        if not transition:
+            raise NotFoundError("Transition", transition_id=transition_id)
+        return TransitionRead.model_validate(transition)
+
+    async def list(
+        self,
+        *,
+        offset: int = 0,
+        limit: int = 50,
+        track_id: int | None = None,
+        min_quality: float | None = None,
+    ) -> TransitionList:
+        if track_id is not None:
+            items, total = await self.repo.list_by_track(track_id, offset=offset, limit=limit)
+        elif min_quality is not None:
+            items, total = await self.repo.list_by_quality(min_quality, offset=offset, limit=limit)
+        else:
+            items, total = await self.repo.list(offset=offset, limit=limit)
+        return TransitionList(
+            items=[TransitionRead.model_validate(t) for t in items],
+            total=total,
+        )
+
+    async def delete(self, transition_id: int) -> None:
+        transition = await self.repo.get_by_id(transition_id)
+        if not transition:
+            raise NotFoundError("Transition", transition_id=transition_id)
+        await self.repo.delete(transition)


### PR DESCRIPTION
     STDIN
   1 ## Summary
   2 
   3 - **8 new routers** with full OpenAPI metadata: artists, labels, releases, genres, sets, playlists, keys, transitions
   4 - **Shared error responses** via `_openapi.py` — DRY 404/409/422 definitions with `ErrorResponse` model
   5 - **Nested resources**: `sets/{id}/versions/{vid}/items`, `playlists/{id}/items`
   6 - **Working CRUD services** wired through `BaseRepository` — immediate functionality, business logic to be added later
   7 - **Pydantic schemas** with `Field` validation matching DB constraints
   8 - **Tracks router upgraded** with `summary`, `description`, `response_description`, `operation_id`, `responses`
   9 - **CLAUDE.md** added to repo
  10 - **Makefile** clean target improved
  11 
  12 ### OpenAPI features per endpoint
  13 | Parameter | Purpose |
  14 |-----------|---------|
  15 | `response_model` | JSON Schema generation + response validation |
  16 | `summary` | Short label in Swagger UI |
  17 | `description` | Detailed Markdown description |
  18 | `response_description` | Describes successful response body |
  19 | `operation_id` | Unique ID for OpenAPI codegen |
  20 | `responses` | Error codes documented (404, 409, 422) |
  21 
  22 ### New endpoints (40 total)
  23 - `/api/v1/artists` — CRUD (5)
  24 - `/api/v1/labels` — CRUD (5)
  25 - `/api/v1/releases` — CRUD + label filter (5)
  26 - `/api/v1/genres` — CRUD (5)
  27 - `/api/v1/sets` — CRUD + versions + items (9)
  28 - `/api/v1/playlists` — CRUD + items (8)
  29 - `/api/v1/keys` — read-only (2)
  30 - `/api/v1/transitions` — list/get/delete with quality filter (3)
  31 
  32 ## Test plan
  33 - [x] All 88 existing tests pass
  34 - [x] ruff check clean
  35 - [x] ruff format clean
  36 - [x] mypy strict clean
  37 - [ ] Verify Swagger UI at `/docs` shows all endpoints with descriptions
  38 - [ ] Test new CRUD endpoints manually (e.g. POST /api/v1/artists)
  39 
  40 🤖 Generated with [Claude Code](https://claude.com/claude-code)